### PR TITLE
Don't compile in the Xposed API

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,5 +23,5 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:21.0.3'
     compile 'com.android.support:support-v4:21.0.3'
-    compile files('lib/XposedBridgeApi-54.jar')
+    provided files('lib/XposedBridgeApi-54.jar')
 }


### PR DESCRIPTION
Per [https://github.com/rovo89/XposedBridge/wiki/Using-the-Xposed-Framework-API](https://github.com/rovo89/XposedBridge/wiki/Using-the-Xposed-Framework-API), the Xposed API should not be compiled in. Starting in Xposed 86, doing so will prevent the module from loading.
